### PR TITLE
feat: Add new Visual Studio solution including Application, Domain, and Infrastructure projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea/

--- a/Domain/Domain.csproj
+++ b/Domain/Domain.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <AssemblyName>LeagueBoss.Domain</AssemblyName>
+        <RootNamespace>LeagueBoss.Domain</RootNamespace>
+    </PropertyGroup>
+
+</Project>

--- a/Infrastructure/Infrastructure.csproj
+++ b/Infrastructure/Infrastructure.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <AssemblyName>LeagueBoss.Infrastructure</AssemblyName>
+        <RootNamespace>LeagueBoss.Infrastructure</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Domain\Domain.csproj" />
+      <ProjectReference Include="..\source\Application\Application.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/league-boss.sln
+++ b/league-boss.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Application", "source\Application\Application.csproj", "{8D5B60C3-3FD3-45DF-AD23-F62C0C4940C5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain", "Domain\Domain.csproj", "{888BEC2A-AF45-4B32-B45D-CC94FD546CF6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infrastructure", "Infrastructure\Infrastructure.csproj", "{45D51D98-A2E2-46D0-B9FC-E9E3111B7B0A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8D5B60C3-3FD3-45DF-AD23-F62C0C4940C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D5B60C3-3FD3-45DF-AD23-F62C0C4940C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D5B60C3-3FD3-45DF-AD23-F62C0C4940C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D5B60C3-3FD3-45DF-AD23-F62C0C4940C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{888BEC2A-AF45-4B32-B45D-CC94FD546CF6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{888BEC2A-AF45-4B32-B45D-CC94FD546CF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{888BEC2A-AF45-4B32-B45D-CC94FD546CF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{888BEC2A-AF45-4B32-B45D-CC94FD546CF6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{45D51D98-A2E2-46D0-B9FC-E9E3111B7B0A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{45D51D98-A2E2-46D0-B9FC-E9E3111B7B0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{45D51D98-A2E2-46D0-B9FC-E9E3111B7B0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{45D51D98-A2E2-46D0-B9FC-E9E3111B7B0A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/source/Application/Application.csproj
+++ b/source/Application/Application.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>LeagueBoss.Application</RootNamespace>
+    <AssemblyName>LeagueBoss.Application</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Domain\Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/source/Application/Program.cs
+++ b/source/Application/Program.cs
@@ -1,0 +1,13 @@
+var builder = WebApplication.CreateBuilder(args);
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.Run();

--- a/source/Application/Properties/launchSettings.json
+++ b/source/Application/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:61961",
+      "sslPort": 44332
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5160",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7080;http://localhost:5160",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/source/Application/appsettings.Development.json
+++ b/source/Application/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/source/Application/appsettings.json
+++ b/source/Application/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
This commit introduces a new Visual Studio solution file for the league-boss project. It includes three projects: Application, Domain, and Infrastructure, each with its respective configuration. Additionally, basic setup for the Application project such as logging settings, launch settings, and references to Swagger middleware has been added. Necessary .gitignore updates are also included.